### PR TITLE
Issue #35

### DIFF
--- a/code/asteroid_walk.py
+++ b/code/asteroid_walk.py
@@ -589,37 +589,37 @@ def handle_builtins(node):
                return ('boolean', False)
         elif opname == '__eq__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real', 'list', 'string']:
+            if type in ['integer', 'real', 'list', 'string', 'boolean']:
                 return ('boolean', val_a[1] == val_b[1])
             else:
                 raise ValueError('unsupported type in ==')
         elif opname  == '__ne__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real', 'list', 'string']:
+            if type in ['integer', 'real', 'list', 'string', 'boolean']:
                 return ('boolean', val_a[1] != val_b[1])
             else:
                 raise ValueError('unsupported type in =/=')
         elif opname == '__le__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real']:
+            if type in ['integer', 'real', 'boolean']:
                 return ('boolean', val_a[1] <= val_b[1])
             else:
                 raise ValueError('unsupported type in <=')
         elif opname == '__lt__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real']:
+            if type in ['integer', 'real', 'boolean']:
                 return ('boolean', val_a[1] < val_b[1])
             else:
                 raise ValueError('unsupported type in <')
         elif opname == '__ge__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real']:
+            if type in ['integer', 'real', 'boolean']:
                 return ('boolean', val_a[1] >= val_b[1])
             else:
                 raise ValueError('unsupported type in >=')
         elif opname == '__gt__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real']:
+            if type in ['integer', 'real', 'boolean']:
                 return ('boolean', val_a[1] > val_b[1])
             else:
                 raise ValueError('unsupported type in >')


### PR DESCRIPTION
Here's a patch fixing issue #35. It correctly asserts the following tests which are in line with the underlying python relational operators.
```
load "io".

-- ==
assert(true == true).
assert(false == false).

-- =/=
assert(true =/= false).
assert(false =/= true).

-- <
assert(not (true < true)).
assert(not (false < false)).

assert(false < true).

-- <=
assert(true <= true).
assert(false <= false).

assert(false <= true).

-- >
assert(not (true > true)).
assert(not (false > false)).

assert(true > false).

-- >=
assert(true >= true).
assert(false >= false).

assert(true >= false).

println("Tests passed").


```