### PR TITLE
Boolean relational operators revision

### DIFF
--- a/code/asteroid_walk.py
+++ b/code/asteroid_walk.py
@@ -601,25 +601,25 @@ def handle_builtins(node):
                 raise ValueError('unsupported type in =/=')
         elif opname == '__le__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real', 'boolean']:
+            if type in ['integer', 'real']:
                 return ('boolean', val_a[1] <= val_b[1])
             else:
                 raise ValueError('unsupported type in <=')
         elif opname == '__lt__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real', 'boolean']:
+            if type in ['integer', 'real']:
                 return ('boolean', val_a[1] < val_b[1])
             else:
                 raise ValueError('unsupported type in <')
         elif opname == '__ge__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real', 'boolean']:
+            if type in ['integer', 'real']:
                 return ('boolean', val_a[1] >= val_b[1])
             else:
                 raise ValueError('unsupported type in >=')
         elif opname == '__gt__':
             type = promote(val_a[0], val_b[0])
-            if type in ['integer', 'real', 'boolean']:
+            if type in ['integer', 'real']:
                 return ('boolean', val_a[1] > val_b[1])
             else:
                 raise ValueError('unsupported type in >')

--- a/code/test-suites/regression-tests/programs/test108.ast
+++ b/code/test-suites/regression-tests/programs/test108.ast
@@ -1,0 +1,8 @@
+-- Testing relational operators on booleans
+-- ==
+assert(true == true).
+assert(false == false).
+
+-- =/=
+assert(true =/= false).
+assert(false =/= true).


### PR DESCRIPTION
Removed unnecessary support for boolean comparisons for <, >, <=, >=.
Additionally, I added a regression test that properly reflects the new functionality.