### PR TITLE
Swapped Precedence Levels for Quote/Conditional Expressions

### DIFF
--- a/code/asteroid_frontend.py
+++ b/code/asteroid_frontend.py
@@ -510,7 +510,7 @@ class Parser:
     #    : conditional
     def exp(self):
         dbg_print("parsing EXP")
-        v = self.conditional()
+        v = self.quote_exp()
         return v
 
     ###########################################################################################
@@ -523,7 +523,7 @@ class Parser:
     def conditional(self):
         dbg_print("parsing CONDITIONAL")
 
-        v = self.quote_exp()
+        v = self.compound()
 
         tt = self.lexer.peek().type
         if tt == 'CMATCH':
@@ -576,7 +576,7 @@ class Parser:
     def head_tail(self):
         dbg_print("parsing HEAD_TAIL")
 
-        v = self.compound()
+        v = self.conditional()
 
         if self.lexer.peek().type == 'BAR':
             self.lexer.match('BAR')

--- a/code/grammar.txt
+++ b/code/grammar.txt
@@ -64,14 +64,7 @@ pattern
   : exp
 
 exp
-  : conditional
-
-conditional
   : quote_exp
-      (
-         (CMATCH exp) |   // CMATCH == '%'IF
-         (IF exp ELSE exp)
-      )?
 
 quote_exp
   : QUOTE head_tail
@@ -79,7 +72,14 @@ quote_exp
   | head_tail
 
 head_tail
-  : compound ('|' exp)?
+  : conditional ('|' exp)?
+
+conditional
+  : compound
+      (
+         (CMATCH exp) |   // CMATCH == '%'IF
+         (IF exp ELSE exp)
+      )?
 
 compound
   : logic_exp0


### PR DESCRIPTION
Swapped the precedence levels of the quote and conditional expressions in the asteroid_frontend and grammar files.

A quote expression now has a higher level of precedence then a conditional expression. This means that in a Asteroid AST representation, a conditional expression node is always below a quote expression node. This allows a conditional expression to be interpreted as a quote, or first-class, expression.

This fixes bug#42.