### PR TITLE
Fixed a typo in the prologue

### DIFF
--- a/code/modules/prologue.ast
+++ b/code/modules/prologue.ast
@@ -314,7 +314,7 @@ self_val = state.symbol_table.lookup_sym('self')
 item_val = state.symbol_table.lookup_sym('item')
 
 if item_val[0] not in ['list', 'string', 'tuple']:
-    raise ValueError('extend expected a list, string, or tuple, got {}''
+    raise ValueError('extend expected a list, string, or tuple, got {}'
                 .format(item_val[0]))
 
 __retval__ = ('list', self_val[1].extend(item_val[1]))


### PR DESCRIPTION
The extend method had a typo where instead of one single quote `'`, there was two `''`.

This leads to an error when trying to use the list@extend method.