### PR TITLE
Fixed ticket #57. Added a regression test for new behavior

### DIFF
--- a/code/asteroid_walk.py
+++ b/code/asteroid_walk.py
@@ -222,6 +222,11 @@ def unify(term, pattern, unifying = True ):
 
         # ttc
         # Should we have an else here?
+        else:
+            raise PatternMatchFailed(
+                "expected typematch {} got an object of type {}"
+                .format(typematch, term[0]))  
+
 
     elif pattern[0] == 'named-pattern':
         # unpack pattern

--- a/code/test-suites/regression-tests/programs/test110.ast
+++ b/code/test-suites/regression-tests/programs/test110.ast
@@ -1,0 +1,10 @@
+load "io".
+
+structure A with
+	data x.
+	end
+
+assert(A(0) is %A).
+assert(3 is %integer).
+assert(not(3 is %A)).
+assert(not(A(0) is %integer)).


### PR DESCRIPTION
Object type patterns can now be matched against non-objects.

That is, this behavior is now valid:
```
load "io".

structure A with
	data x.
	end

assert(not(3 is %A)). -- This asserts correctly
```