### PR TITLE
Issue 27: Non-linear Patterns

### DIFF
--- a/code/asteroid_globals.py
+++ b/code/asteroid_globals.py
@@ -79,6 +79,14 @@ class PatternMatchFailed(Exception):
     def __str__(self):
         return(repr(self.value))
 
+#########################################################################
+class NonLinearPatternError(Exception):
+    def __init__(self, value):
+        self.value = "non-linear pattern error: " + value
+
+    def __str__(self):
+        return(repr(self.value))
+
 ##############################################################################################
 # *** Part of the Redundant Pattern Detector ***
 #

--- a/code/asteroid_interp.py
+++ b/code/asteroid_interp.py
@@ -6,7 +6,7 @@
 
 import sys
 from asteroid_globals import *
-from  asteroid_support import *
+from asteroid_support import *
 from pathlib import Path
 from asteroid_frontend import Parser
 from asteroid_state import state
@@ -90,6 +90,10 @@ def interp(input_stream,
         sys.exit(1)
 
     except RedundantPatternFound as e:
+        print("Error:  {}".format(e))
+        sys.exit(1)
+    
+    except NonLinearPatternError as e:
         print("Error:  {}".format(e))
         sys.exit(1)
 

--- a/code/asteroid_walk.py
+++ b/code/asteroid_walk.py
@@ -477,8 +477,8 @@ def check_repeated_symbols( unifiers ):
             skip_unifier = False
 
         elif sym in symbols: # We have found a non-linear pattern
-            raise PatternMatchFailed(
-            "Non-linear pattern dectected. Multiple instances of {} found within a pattern.".format(sym))
+            raise NonLinearPatternError(
+            "multiple instances of {} found within a pattern.".format(sym))
 
         else: # Ekse we have never seen this before so we record it.
             symbols[sym] = term

--- a/code/asteroid_walk.py
+++ b/code/asteroid_walk.py
@@ -450,7 +450,7 @@ def declare_formal_args(unifiers):
 # names within a pattern. Repeated variables names within the same pattern
 # are what is called a non-linear pattern, which is not currently supported
 # by Asteroid. 
-# This function will raise a PatternMatchFailed exception when a non-linear
+# This function will raise a NonLinearPatternError exception when a non-linear
 # pattern has been recognized.
 # Otherwise, this function returns control to the caller after finishing.
 def check_repeated_symbols( unifiers ):
@@ -480,7 +480,7 @@ def check_repeated_symbols( unifiers ):
             raise NonLinearPatternError(
             "multiple instances of {} found within a pattern.".format(sym))
 
-        else: # Ekse we have never seen this before so we record it.
+        else: # Else we have never seen this before so we record it.
             symbols[sym] = term
 
 #########################################################################
@@ -939,6 +939,15 @@ def try_stmt(node):
                          ('object-memory',
                           ('list',
                            [('string', 'RedundantPatternFound'),
+                            ('string', str(inst))])))
+        inst_val = inst
+
+    except NonLinearPatternError as inst:
+        except_val = ('object',
+                         ('struct-id', ('id', 'Exception')),
+                         ('object-memory',
+                          ('list',
+                           [('string', 'NonLinearPatternError'),
                             ('string', str(inst))])))
         inst_val = inst
 

--- a/code/test-suites/regression-tests/programs/test015.ast
+++ b/code/test-suites/regression-tests/programs/test015.ast
@@ -1,6 +1,15 @@
 
 load "io".
+load "util".
 
 -- TODO: this is NOT correct see issue #27
-let (x,x) = (1,2).
-println x.
+try
+    let (x,x) = (1,2).
+    println x.
+catch Exception(kind, s) do
+    if not isnone(s @index("Non-linear")) do
+        . -- pass
+    else
+        throw Error("FAIL: unexpected error "+s).
+    end.
+end.

--- a/code/test-suites/regression-tests/programs/test015.ast
+++ b/code/test-suites/regression-tests/programs/test015.ast
@@ -7,36 +7,39 @@ load "util".
 try
     let (x,x) = (1,1).
     println x.
-catch Exception(kind, s) do
-    if not isnone(s @index("non-linear")) do
-        println("PASSED.").
-    else
-        println("FAILED.").
-        throw Error("FAIL: unexpected error "+s).
-    end.
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
 end.
 --------------------------------------------------TEST2--
 try
     let [x,w,y,[a,b,x]] = [1,2,3,[1,2,1]].
     println x.
-catch Exception(kind, s) do
-    if not isnone(s @index("non-linear")) do
-        println("PASSED.").
-    else
-        println("FAILED.").
-        throw Error("FAIL: unexpected error "+s).
-    end.
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
 end.
 --------------------------------------------------TEST3--
 try
     let (name:%string,name:%string) = ("a","a").
-catch Exception(kind, s) do
-    if not isnone(s @index("non-linear")) do
-        println("PASSED.")
-    else
-        println("FAILED.").
-        throw Error("FAIL: unexpected error "+s).
-    end.
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
 end.
 --------------------------------------------------TEST4--
 try
@@ -44,24 +47,26 @@ try
     let p2 = pattern with x.
     let p3 = pattern with (*p1,*p2).
     let *p3 = ("a","a").
-catch Exception(kind, s) do
-    if not isnone(s @index("non-linear")) do
-        println("PASSED.")
-    else
-        println("FAILED.").
-        throw Error("FAIL: unexpected error "+s).
-    end.
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
 end.
 --------------------------------------------------TEST5--
 try
     let false = ((1,1) is (x,x)).
-catch Exception(kind, s) do
-    if not isnone(s @index("non-linear")) do
-        println("PASSED.")
-    else
-        println("FAILED.").
-        throw Error("FAIL: unexpected error "+s).
-    end.
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
 end.
 --------------------------------------------------TEST6--
 try
@@ -74,14 +79,15 @@ try
             return 3.
         end.
 
-    assert( foo( (1,1) ) == 2 ).
-catch Exception(kind, s) do
-    if not isnone(s @index("non-linear")) do
-        println("PASSED.")
-    else
-        println("FAILED.").
-        throw Error("FAIL: unexpected error "+s).
-    end.
+    foo( (1,1) ).
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
 end.
 --------------------------------------------------TEST7--
 try
@@ -99,12 +105,46 @@ try
     end.
 
     assert(counter == 3).
-catch Exception(kind, s) do
-    if not isnone(s @index("non-linear")) do
-        println("PASSED.")
-    else
-        println("FAILED.").
-        throw Error("FAIL: unexpected error "+s).
-    end.
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
+end.
+--------------------------------------------------TEST8--
+try
+    function foo
+        with [ x | x | tail ] do
+            return 1.
+        orwith [x | y | tail] do
+            return 2.
+        orwith x do
+            return 3.
+        end.
+
+    foo( [1,1,1,1] ).
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
+end.
+--------------------------------------------------TEST9--
+try
+    let (x,x:%integer) = (1,1).
+
+    println("FAILED.").
+    throw Error("FAIL: no error").
+catch Exception("NonLinearPatternError", s) do
+    println("PASSED.").
+catch _ do
+    println("FAILED.").
+    throw Error("FAIL: unexpected error").
 end.
 --------------------------------------------------END----

--- a/code/test-suites/regression-tests/programs/test015.ast
+++ b/code/test-suites/regression-tests/programs/test015.ast
@@ -3,49 +3,108 @@ load "io".
 load "util".
 
 -- UPDATED 6-28-21 to reflect issue #27 resolution
---------------------------------------------------
+--------------------------------------------------TEST1--
 try
     let (x,x) = (1,1).
     println x.
 catch Exception(kind, s) do
-    if not isnone(s @index("Non-linear")) do
+    if not isnone(s @index("non-linear")) do
         println("PASSED.").
     else
+        println("FAILED.").
         throw Error("FAIL: unexpected error "+s).
     end.
 end.
---------------------------------------------------
+--------------------------------------------------TEST2--
 try
     let [x,w,y,[a,b,x]] = [1,2,3,[1,2,1]].
     println x.
 catch Exception(kind, s) do
-    if not isnone(s @index("Non-linear")) do
+    if not isnone(s @index("non-linear")) do
         println("PASSED.").
     else
+        println("FAILED.").
         throw Error("FAIL: unexpected error "+s).
     end.
 end.
---------------------------------------------------
+--------------------------------------------------TEST3--
 try
     let (name:%string,name:%string) = ("a","a").
 catch Exception(kind, s) do
-    if not isnone(s @index("Non-linear")) do
+    if not isnone(s @index("non-linear")) do
         println("PASSED.")
     else
+        println("FAILED.").
         throw Error("FAIL: unexpected error "+s).
     end.
 end.
---------------------------------------------------
+--------------------------------------------------TEST4--
 try
     let p1 = pattern with x.
     let p2 = pattern with x.
     let p3 = pattern with (*p1,*p2).
     let *p3 = ("a","a").
 catch Exception(kind, s) do
-    if not isnone(s @index("Non-linear")) do
+    if not isnone(s @index("non-linear")) do
         println("PASSED.")
     else
+        println("FAILED.").
         throw Error("FAIL: unexpected error "+s).
     end.
 end.
---------------------------------------------------
+--------------------------------------------------TEST5--
+try
+    let false = ((1,1) is (x,x)).
+catch Exception(kind, s) do
+    if not isnone(s @index("non-linear")) do
+        println("PASSED.")
+    else
+        println("FAILED.").
+        throw Error("FAIL: unexpected error "+s).
+    end.
+end.
+--------------------------------------------------TEST6--
+try
+    function foo
+        with (x,x) do
+            return 1.
+        orwith (x,y) do
+            return 2.
+        orwith x do
+            return 3.
+        end.
+
+    assert( foo( (1,1) ) == 2 ).
+catch Exception(kind, s) do
+    if not isnone(s @index("non-linear")) do
+        println("PASSED.")
+    else
+        println("FAILED.").
+        throw Error("FAIL: unexpected error "+s).
+    end.
+end.
+--------------------------------------------------TEST7--
+try
+    let myList = [ (1,1) , (2,2) , (3,3) ].
+    let counter = 0.
+
+    for (x,x) in myList do
+        let counter = counter + 1.
+    end.
+
+    assert(counter == 0).
+
+    for (x,y) in myList do
+        let counter = counter + 1.
+    end.
+
+    assert(counter == 3).
+catch Exception(kind, s) do
+    if not isnone(s @index("non-linear")) do
+        println("PASSED.")
+    else
+        println("FAILED.").
+        throw Error("FAIL: unexpected error "+s).
+    end.
+end.
+--------------------------------------------------END----

--- a/code/test-suites/regression-tests/programs/test015.ast
+++ b/code/test-suites/regression-tests/programs/test015.ast
@@ -2,13 +2,50 @@
 load "io".
 load "util".
 
+-- UPDATED 6-28-21 to reflect issue #27 resolution
+--------------------------------------------------
 try
-    let (x,x) = (1,2).
+    let (x,x) = (1,1).
     println x.
 catch Exception(kind, s) do
     if not isnone(s @index("Non-linear")) do
-        . -- pass
+        println("PASSED.").
     else
         throw Error("FAIL: unexpected error "+s).
     end.
 end.
+--------------------------------------------------
+try
+    let [x,w,y,[a,b,x]] = [1,2,3,[1,2,1]].
+    println x.
+catch Exception(kind, s) do
+    if not isnone(s @index("Non-linear")) do
+        println("PASSED.").
+    else
+        throw Error("FAIL: unexpected error "+s).
+    end.
+end.
+--------------------------------------------------
+try
+    let (name:%string,name:%string) = ("a","a").
+catch Exception(kind, s) do
+    if not isnone(s @index("Non-linear")) do
+        println("PASSED.")
+    else
+        throw Error("FAIL: unexpected error "+s).
+    end.
+end.
+--------------------------------------------------
+try
+    let p1 = pattern with x.
+    let p2 = pattern with x.
+    let p3 = pattern with (*p1,*p2).
+    let *p3 = ("a","a").
+catch Exception(kind, s) do
+    if not isnone(s @index("Non-linear")) do
+        println("PASSED.")
+    else
+        throw Error("FAIL: unexpected error "+s).
+    end.
+end.
+--------------------------------------------------

--- a/code/test-suites/regression-tests/programs/test015.ast
+++ b/code/test-suites/regression-tests/programs/test015.ast
@@ -2,7 +2,6 @@
 load "io".
 load "util".
 
--- TODO: this is NOT correct see issue #27
 try
     let (x,x) = (1,2).
     println x.


### PR DESCRIPTION
Non-linear patterns are now recognized by the Asteroid Interpreter. 

It is the current behavior of the Asteroid Interpreter to generate an error and print an error message to the console when a non-linear pattern has been recognized. The error type generated is a new type of error, the `NonLinearPatternError` error.

The `NonLinearPatternError` is a runtime error.