### PR TITLE
Patterns are now available for typematching

### DIFF
--- a/code/asteroid_walk.py
+++ b/code/asteroid_walk.py
@@ -199,6 +199,14 @@ def unify(term, pattern, unifying = True ):
                     "expected typematch {} got a term of type {}"
                     .format(typematch, term[0]))
 
+        elif typematch == 'pattern':
+            if term[0] == 'quote':
+                return []
+            else:
+                raise PatternMatchFailed(
+                                    "expected typematch {} got a term of type {}"
+                                    .format(typematch, term[0]))
+
         elif term[0] == 'object':
             (OBJECT,
                 (STRUCT_ID, (ID, struct_id)),

--- a/code/test-suites/regression-tests/programs/test119.ast
+++ b/code/test-suites/regression-tests/programs/test119.ast
@@ -12,9 +12,15 @@ let THREE_POINTS = pattern with ( *POINT_ONE , *POINT_TWO , *POINT_THREE ).
 
 function foo
     with x:%pattern do
-        println("pattern typecheck works").
+        println("is a pattern").
     orwith _ do
-        println("pattern typecheck does not work").
+        println("not a pattern").
         end
 
+-- Should match as a pattern
 foo(THREE_POINTS).
+
+-- Should not match as a pattern
+foo("Asteroid").
+foo(123).
+foo((1,2,3)).

--- a/code/test-suites/regression-tests/programs/test119.ast
+++ b/code/test-suites/regression-tests/programs/test119.ast
@@ -1,0 +1,20 @@
+load system "io".
+
+let COORDINATE = pattern with (x,y).
+let COORDINATE_LIST = pattern with coordinates:%list.
+let POINTS = pattern with points:%integer.
+let COORDINATES = pattern with ( *COORDINATE_LIST , *POINTS ).
+let POINT_ONE =   pattern with p1:(x1,y1).
+let POINT_TWO =   pattern with p2:(x2,y2).
+let POINT_THREE = pattern with p3:(x3,y3).
+let TWO_POINTS =   pattern with ( *POINT_ONE , *POINT_TWO ).
+let THREE_POINTS = pattern with ( *POINT_ONE , *POINT_TWO , *POINT_THREE ). 
+
+function foo
+    with x:%pattern do
+        println("pattern typecheck works").
+    orwith _ do
+        println("pattern typecheck does not work").
+        end
+
+foo(THREE_POINTS).


### PR DESCRIPTION
This PR gives typematching an extension to now be able to match against patterns.

Example:
```
load system "io".
let x = pattern with (a,b,c).

-- Prints out true
println(x is %pattern).
```