### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ setup(
     url="https://github.com/lutzhamel/asteroid",
     packages=find_packages(),
     package_data={"asteroid": ["modules/*"]},
+    install_requires={
+        "pandas",
+        "numpy",
+        "matplotlib"
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -22,7 +27,7 @@ setup(
     python_requires=">=3.6",
     entry_points={
         "console_scripts": [
-            'asteroid = asteroid:main',
+            "asteroid = asteroid:main",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ setup(
     url="https://github.com/lutzhamel/asteroid",
     packages=find_packages(),
     package_data={"asteroid": ["modules/*"]},
-    install_requires={
+    install_requires=[
         "pandas",
         "numpy",
         "matplotlib"
-    },
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
This pull request adds the dependencies `numpy`, `pandas`, and `matplotlib` to `setup.py` as requirements—something I should have done in my last PR.

I tested this by installing Asteroid in a fresh Repl.it environment that didn't have all of these dependencies and ran the test cases.